### PR TITLE
Have smoketest use binary Zeek releases

### DIFF
--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - smoketest-binary-zeek
 
 jobs:
   smoketest:

--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - smoketest-binary-zeek
+      - master
 
 jobs:
   smoketest:

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -10,22 +10,19 @@ else
   PACKAGE_SHA="$PULL_REQUEST_HEAD_SHA"
 fi
 
-# Alas, we must compile Zeek because I've found the binary distributions are
-# not compiled with libmaxminddb.
-apt-get update
-apt-get install cmake make gcc g++ flex bison libpcap-dev libssl-dev python-dev swig zlib1g-dev libmaxminddb-dev
-git clone --recursive https://github.com/zeek/zeek zeek-src
-cd zeek-src
-./configure --prefix=/usr/local/zeek
-make -j$(nproc)
-make -j$(nproc) install
+# Install the latest binary feature release build of Zeek per instructions at
+# https://software.opensuse.org//download.html?project=security%3Azeek&package=zeek
+echo 'deb http://download.opensuse.org/repositories/security:/zeek/xUbuntu_18.04/ /' | sudo tee /etc/apt/sources.list.d/security:zeek.list
+curl -fsSL https://download.opensuse.org/repositories/security:zeek/xUbuntu_18.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/security:zeek.gpg > /dev/null
+sudo apt update
+sudo apt -y install zeek
 
 # Add Zeek Package Manager and current revision of the geoip-conn package
 pip install zkg
-export PATH="/usr/local/zeek/bin:$PATH"
+export PATH="/opt/zeek/bin:$PATH"
 zkg autoconfig
 zkg install --force geoip-conn --version "$PACKAGE_SHA"
-echo '@load packages' | tee -a /usr/local/zeek/share/zeek/site/local.zeek
+echo '@load packages' | tee -a /opt/zeek/share/zeek/site/local.zeek
 
 # Do a lookup of an IP that's known to have a stable location.
 zeek -e "print lookup_location(199.83.220.115);" local | grep "San Francisco"


### PR DESCRIPTION
Back when I first created this Zeek Package, the [binary Zeek releases](https://software.opensuse.org//download.html?project=security%3Azeek&package=zeek) weren't compiled with libmaxminddb support, so I couldn't install geoip-conn via Zeek Package Manager atop those in order to smoke test. Instead I was compiling Zeek from source with every smoke test so I could start from a libmaxminddb-enabled install. But starting with today's release of Zeek 3.2.1, I've confirmed the binary Zeek now has that support enabled/working. In this PR I've modified the Action to use the binary installs instead of compiling. This brings the smoke test time down from 23+ minutes to ~2 minutes.