### PR TITLE
GitHub Action to download current DB and make a PR

### DIFF
--- a/.github/workflows/update-geolite2.yml
+++ b/.github/workflows/update-geolite2.yml
@@ -1,0 +1,36 @@
+name: Create a PR to update the GeoLite2 database
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-db:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: geoip-conn
+    - name: Download latest GeoLite2 City database
+      run: |
+        curl -o geo.tgz "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&suffix=tar.gz&license_key=${{ secrets.MAXMIND_LICENSE_KEY }}"
+        tar xzvf geo.tgz
+        mv GeoLite2*/GeoLite2-City.mmdb geoip-conn/zeek
+    - name: Extract datestamp
+      run: |
+        GEODIR=$(ls -d Geo*)
+        DATESTR=$(echo $GEODIR | cut -f2 -d_)
+        YEAR=${DATESTR:0:4}
+        MONTH=${DATESTR:4:2}
+        DAY=${DATESTR:6:2}
+        DATESTAMP="${YEAR}-${MONTH}-${DAY}"
+        echo "##[set-output name=datestmp;]$(echo ${DATESTAMP})"
+      id: extract_datestamp
+    - name: Create Pull Request containing updated GeoLite2 database
+      uses: peter-evans/create-pull-request@v3
+      with:
+        path: geoip-conn
+        commit-message: Update GeoLite2 database to ${{ steps.extract_datestamp.outputs.datestmp }} release
+        branch: geolite2-update-${{ steps.extract_datestamp.outputs.datestmp }}
+        delete-branch: true
+        title: Update GeoLite2 database to ${{ steps.extract_datestamp.outputs.datestmp }} release
+        reviewers: philrz


### PR DESCRIPTION
Some time ago @alfred-landrum found the script [update_geoip.bat](https://wiki.wireshark.org/Tools?action=AttachFile&do=view&target=update_geoip.bat) that showed us that folks are automating their updates of MaxMind GeoIP databases. To save me a few minutes every Tuesday when MaxMind publishes the updates, the Action in this PR would allow me to complete the update in two clicks:

1. Click the "Run Workflow" button on the Actions tab for the repo. This will make a PR that includes the updated DB, which in turn will trigger the smoke test that confirms the Zeek package still works with the new DB.

2. Click the "Merge" button when I see the smoke test ran successfully.

After I wrote what's here, I realized that to be extra fancy I could have it run on a cron-style schedule such that it checks periodically to see when MaxMind publishes the new version and use that as a trigger for the first step. However, for now I'm happy to run with what's here for a while and see how it goes.