### PR TITLE
Fix smoketest to work with zkg 2.5.0

### DIFF
--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - fix-smoketest
 
 jobs:
   smoketest:

--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - fix-smoketest
 
 jobs:
   smoketest:

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -20,8 +20,8 @@ sudo apt -y install zeek python3-setuptools
 # Add Zeek Package Manager and current revision of the geoip-conn package
 pip3 install zkg wheel
 export PATH="/opt/zeek/bin:$PATH"
-~/.local/bin/zkg autoconfig
-~/.local/bin/zkg install --force geoip-conn --version "$PACKAGE_SHA"
+zkg autoconfig
+zkg install --force geoip-conn --version "$PACKAGE_SHA"
 echo '@load packages' | tee -a /opt/zeek/share/zeek/site/local.zeek
 
 # Do a lookup of an IP that's known to have a stable location.

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -18,7 +18,7 @@ sudo apt update
 sudo apt -y install zeek
 
 # Add Zeek Package Manager and current revision of the geoip-conn package
-pip install zkg
+pip3 install zkg
 export PATH="/opt/zeek/bin:$PATH"
 zkg autoconfig
 zkg install --force geoip-conn --version "$PACKAGE_SHA"

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -15,13 +15,13 @@ fi
 echo 'deb http://download.opensuse.org/repositories/security:/zeek/xUbuntu_18.04/ /' | sudo tee /etc/apt/sources.list.d/security:zeek.list
 curl -fsSL https://download.opensuse.org/repositories/security:zeek/xUbuntu_18.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/security:zeek.gpg > /dev/null
 sudo apt update
-sudo apt -y install zeek
+sudo apt -y install zeek python3-setuptools
 
 # Add Zeek Package Manager and current revision of the geoip-conn package
-pip3 install zkg
+pip3 install zkg wheel
 export PATH="/opt/zeek/bin:$PATH"
-zkg autoconfig
-zkg install --force geoip-conn --version "$PACKAGE_SHA"
+~/.local/bin/zkg autoconfig
+~/.local/bin/zkg install --force geoip-conn --version "$PACKAGE_SHA"
 echo '@load packages' | tee -a /opt/zeek/share/zeek/site/local.zeek
 
 # Do a lookup of an IP that's known to have a stable location.


### PR DESCRIPTION
Zeek Package Manager v2.5.0 came out, which broke the smoker tester in this repo. The error messages all appeared Python2-related. Indeed, the zkg docs now all explicitly mention `pip3`, so I've taken that approach here and it does makes it work again.