### PR TITLE
Upgrade to actions/checkout@v3 in CI

### DIFF
--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -15,5 +15,5 @@ jobs:
     env:
         PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - run: sudo -E ./smoketest.sh

--- a/.github/workflows/update-geolite2.yml
+++ b/.github/workflows/update-geolite2.yml
@@ -7,7 +7,7 @@ jobs:
   update-db:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         path: geoip-conn
     - name: Download latest GeoLite2 City database


### PR DESCRIPTION
v2 is deprecated because it uses Node.js 12, which is no longer supported.

(inspired by https://github.com/brimdata/zed/pull/4185)