### PR TITLE
Add autonomous system info to Zeek conn records

### DIFF
--- a/.github/workflows/update-geolite2.yml
+++ b/.github/workflows/update-geolite2.yml
@@ -10,11 +10,14 @@ jobs:
     - uses: actions/checkout@v3
       with:
         path: geoip-conn
-    - name: Download latest GeoLite2 City database
+    - name: Download GeoLite2 databases
       run: |
-        curl -o geo.tgz "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&suffix=tar.gz&license_key=${{ secrets.MAXMIND_LICENSE_KEY }}"
-        tar xzvf geo.tgz
+        curl -o geo-city.tgz "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&suffix=tar.gz&license_key=${{ secrets.MAXMIND_LICENSE_KEY }}"
+        tar xzvf geo-city.tgz
         mv GeoLite2*/GeoLite2-City.mmdb geoip-conn/zeek
+        curl -o geo-asn.tgz "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-ASN&suffix=tar.gz&license_key=${{ secrets.MAXMIND_LICENSE_KEY }}"
+        tar xzvf geo-asn.tgz
+        mv GeoLite2*/GeoLite2-ASN.mmdb geoip-conn/zeek
     - name: Extract datestamp
       run: |
         GEODIR=$(ls -d Geo*)

--- a/README.md
+++ b/README.md
@@ -3,15 +3,17 @@
 ## Summary
 
 If you have Zeek compiled with
-[GeoLocation support](https://docs.zeek.org/en/current/frameworks/geoip.html),
+[GeoLocation support](https://docs.zeek.org/en/current/customizations.html#address-geolocation-and-as-lookups),
 this package will add a nested record called `geo` to the `conn` log that
-conains fields for each originating and responding IP that describe:
+contains fields for each originating and responding IP that describe:
 
 * Country code
 * Region
 * City
 * Latitude
 * Longitude
+* Autonomous System Number
+* Autonomous System Organization
 
 A [GeoLite2](https://dev.maxmind.com/geoip/geoip2/geolite2/) geolocation
 database is included with the package for out-of-the-box functionality.
@@ -32,16 +34,16 @@ more than just country info.
 
 ## About the included GeoLite2 database
 
-Per the [MaxMind FAQ](https://support.maxmind.com/geolite-faq/), the free
-GeoLite2 database is less accurate than the paid [GeoIP2](https://www.maxmind.com/en/geoip2-databases)
-version. While the author of this package has not attempted it, the FAQ
-indicates that the paid version should work as a "drop-in replacement".
+Per [MaxMind documentation](https://support.maxmind.com/hc/en-us/articles/4407625342875-Upgrade-from-GeoLite2), the free
+GeoLite2 database is less accurate than the paid GeoIP2
+version. While the author of this package has not attempted it, the docs
+indicate that the paid version should work as a "drop-in replacement".
 
-The MaxMind FAQ also indicates the database is updated weekly, every Tuesday.
-All attempts will be made to keep the database verison in this repo current.
+The MaxMind docs also indicate the database is updated weekly, every Tuesday.
+All attempts will be made to keep the database version in this repo current.
 However, if you're concerned about accuracy, you may want to create your own
 MaxMind login and keep your local copy up to date.
 
-If you delete the database file `GeoLite2-City.mmdb` that comes with this
-package, Zeek will fall back to looking for a database in
-[default locations](https://github.com/zeek/zeek/blob/09483619ef0839cad189f22c4d5be3d66cedcf55/src/zeek.bif#L3964-L3971).
+If you delete the database files `GeoLite2-City.mmdb` and `GeoLite2-ASN.mmdb` that come with this
+package, Zeek will fall back to looking for databases in default locations. See
+[zeek/zeek#3547](https://github.com/zeek/zeek/pull/3547) for details.

--- a/zeek/geoip-conn.zeek
+++ b/zeek/geoip-conn.zeek
@@ -19,6 +19,8 @@ export {
 		city: string &optional &log;
 		latitude: double &optional &log;
 		longitude: double &optional &log;
+		as_number: count &optional &log;
+		as_org: string &optional &log;
 	};
 
 	type GeoPair: record {
@@ -45,6 +47,11 @@ event connection_state_remove(c: connection)
 		orig_geo$latitude = orig_loc$latitude;
 	if ( orig_loc?$longitude )
 		orig_geo$longitude = orig_loc$longitude;
+	local orig_as_info = lookup_autonomous_system(c$id$orig_h);
+	if ( orig_as_info?$number )
+		orig_geo$as_number = orig_as_info$number;
+	if ( orig_as_info?$organization )
+		orig_geo$as_org = orig_as_info$organization;
 
 	local resp_geo: GeoInfo;
 	local resp_loc = lookup_location(c$id$resp_h);
@@ -58,6 +65,11 @@ event connection_state_remove(c: connection)
 		resp_geo$latitude = resp_loc$latitude;
 	if ( resp_loc?$longitude )
 		resp_geo$longitude = resp_loc$longitude;
+	local resp_as_info = lookup_autonomous_system(c$id$resp_h);
+	if ( resp_as_info?$number )
+		resp_geo$as_number = resp_as_info$number;
+	if ( resp_as_info?$organization )
+		resp_geo$as_org = resp_as_info$organization;
 
 	local geo_pair: GeoPair;
 	geo_pair$orig = orig_geo;
@@ -66,4 +78,3 @@ event connection_state_remove(c: connection)
 	c$conn$geo = geo_pair;
 
 	}
-


### PR DESCRIPTION
This was a change first requested by a community user in #39. Shortly after the issue was first opened I prototyped the change and opened https://github.com/zeek/zeek/pull/2147 to further enhance Zeek to provide additional detail that was desired. Even as newer Zeek releases included that functionality, we've only recently been able to start bundling current Zeek releases for inclusion with Brimcap/Zui, so we're now able to move forward with delivering the enhancement in this Zeek package so those projects can benefit as well.

This PR brings everything current by:

1. Enhancing the CI build automation to download the additional ASN database file from MaxMind for inclusion with the package
2. Enhancing the Zeek script to include the additional ASN fields as part of Zeek's `conn` records
3. Updating the README to reflect the new fields and also to adjust some links that have changed in the past couple years

Here's an example of when the package from this branch is used to process the test data [dns/loc-29-trunc.pcap](https://github.com/zeek/zeek/raw/master/testing/btest/Traces/dns/loc-29-trunc.pcap):

```
$ zq -Z 'cut geo | head 1' conn.log
{
    geo: {
        orig: {
            country_code: "CH",
            region: "GE",
            city: "Geneva",
            latitude: 46.2333,
            longitude: 6.1167,
            as_number: 44166 (uint64),
            as_org: "NTD SA"
        },
        resp: {
            country_code: "US",
            region: null (string),
            city: null (string),
            latitude: 37.751,
            longitude: -97.822,
            as_number: 3443 (uint64),
            as_org: "ESNET-AS"
        }
    }
}
```

Closes #39