### PR TITLE
Use new Maxmind URLs for downloading geolocation DBs

### DIFF
--- a/.github/workflows/update-geolite2.yml
+++ b/.github/workflows/update-geolite2.yml
@@ -12,10 +12,10 @@ jobs:
         path: geoip-conn
     - name: Download GeoLite2 databases
       run: |
-        curl -o geo-city.tgz "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&suffix=tar.gz&license_key=${{ secrets.MAXMIND_LICENSE_KEY }}"
+        curl -o geo-city.tgz -J -L -u ${{ secrets.MAXMIND_ACCOUNT_ID }}:${{ secrets.MAXMIND_LICENSE_KEY }} 'https://download.maxmind.com/geoip/databases/GeoLite2-City/download?suffix=tar.gz'
         tar xzvf geo-city.tgz
         mv GeoLite2*/GeoLite2-City.mmdb geoip-conn/zeek
-        curl -o geo-asn.tgz "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-ASN&suffix=tar.gz&license_key=${{ secrets.MAXMIND_LICENSE_KEY }}"
+        curl -o geo-asn.tgz -J -L -u ${{ secrets.MAXMIND_ACCOUNT_ID }}:${{ secrets.MAXMIND_LICENSE_KEY }} 'https://download.maxmind.com/geoip/databases/GeoLite2-ASN/download?suffix=tar.gz'
         tar xzvf geo-asn.tgz
         mv GeoLite2*/GeoLite2-ASN.mmdb geoip-conn/zeek
     - name: Extract datestamp


### PR DESCRIPTION
Maxmind recently changed their URLs and auth approach for downloading databases ([docs](https://dev.maxmind.com/geoip/updating-databases#directly-downloading-databases)). This branch conforms to the new approach when doing weekly updates. It's been tested successfully with scratch PR #50.